### PR TITLE
Use :db/retractEntity and remove unneeded functions

### DIFF
--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -249,24 +249,6 @@
           (recur (get ch (dec n))))))))
 
 
-(defn get-id
-  [uid]
-  (-> (d/q '[:find ?id
-             :in $ ?uid
-             :where [?id :block/uid ?uid]]
-           @dsdb
-           uid)
-      ffirst))
-
-
-(defn get-children-recursively
-  "Get list of children UIDs for given block ID (including the root block's UID)"
-  [uid]
-  (let [document (->> @(pull dsdb '[:block/order :block/uid {:block/children ...}] (get-id uid)))]
-    (->> (tree-seq :block/children :block/children document)
-         (map :block/uid))))
-
-
 (defn re-case-insensitive
   "More options here https://clojuredocs.org/clojure.core/re-pattern"
   [query]

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -1,6 +1,6 @@
 (ns athens.events
   (:require
-    [athens.db :as db :refer [rules get-children-recursively]]
+    [athens.db :as db :refer [rules]]
     [athens.util :refer [now-ts gen-block-uid]]
     [datascript.core :as d]
     [datascript.transit :as dt]
@@ -110,14 +110,14 @@
     (let [first-item (first selected-items)
           prev-block-uid- (db/prev-block-uid first-item)
           prev-block (db/get-block [:block/uid prev-block-uid-])
-          ;;parent (db/get-parent [:block/uid first-item])
+         ;;parent (db/get-parent [:block/uid first-item])
           new-vec (cond
-                    ;; if prev-block is root node TODO: (OR context root), don't do anything
+                   ;; if prev-block is root node TODO: (OR context root), don't do anything
                     (:node/title prev-block) nil
-                    ;; if prev block is parent, replace head of vector with parent
-                    ;; TODO needs to replace all children blocks of the parent
-                    ;; TODO: needs to delete blocks recursively. :db/retractEntity does not delete recursively, which would create orphan blocks
-                    ;;(= (:block/uid parent) prev-block-uid-) (assoc selected-items 0 prev-block-uid-)
+                   ;; if prev block is parent, replace head of vector with parent
+                   ;; TODO needs to replace all children blocks of the parent
+                   ;; TODO: needs to delete blocks recursively. :db/retractEntity does not delete recursively, which would create orphan blocks
+                   ;;(= (:block/uid parent) prev-block-uid-) (assoc selected-items 0 prev-block-uid-)
                     :else (into [prev-block-uid-] selected-items))]
       (assoc db :selected/items new-vec))))
 
@@ -287,7 +287,7 @@
 (reg-event-fx
   :page/delete
   (fn [_ [_ uid]]
-    {:transact! (vec (map (fn [uid] [:db/retract [:block/uid uid] :block/uid]) (get-children-recursively uid)))}))
+    {:transact! [[:db/retractEntity [:block/uid uid]]]}))
 
 
 (reg-event-fx
@@ -342,7 +342,7 @@
 (reg-event-fx
   :up
   (fn [_ [_ uid]]
-    ;; FIXME: specify behavior when going up would go to title or context-root
+   ;; FIXME: specify behavior when going up would go to title or context-root
     {:dispatch [:editing/uid (or (db/prev-block-uid uid) uid)]}))
 
 


### PR DESCRIPTION
* `:db/retractEntity` allows us to retract an entity and all component entities recursively.
* Remove get-id and get-children-recursively functions since we don't need them anymore.