### PR TITLE
fix: recursive retraction of all child entities

### DIFF
--- a/src/cljs/athens/db.cljs
+++ b/src/cljs/athens/db.cljs
@@ -249,6 +249,24 @@
           (recur (get ch (dec n))))))))
 
 
+(defn get-id
+  [uid]
+  (-> (d/q '[:find ?id
+             :in $ ?uid
+             :where [?id :block/uid ?uid]]
+           @dsdb
+           uid)
+      ffirst))
+
+
+(defn get-children-recursively
+  "Get list of children UIDs for given block ID (including the root block's UID)"
+  [uid]
+  (let [document (->> @(pull dsdb '[:block/order :block/uid {:block/children ...}] (get-id uid)))]
+    (->> (tree-seq :block/children :block/children document)
+         (map :block/uid))))
+
+
 (defn re-case-insensitive
   "More options here https://clojuredocs.org/clojure.core/re-pattern"
   [query]

--- a/src/cljs/athens/events.cljs
+++ b/src/cljs/athens/events.cljs
@@ -1,6 +1,6 @@
 (ns athens.events
   (:require
-    [athens.db :as db :refer [rules]]
+    [athens.db :as db :refer [rules get-children-recursively]]
     [athens.util :refer [now-ts gen-block-uid]]
     [datascript.core :as d]
     [datascript.transit :as dt]
@@ -287,7 +287,7 @@
 (reg-event-fx
   :page/delete
   (fn [_ [_ uid]]
-    {:transact! [[:db/retractEntity [:block/uid uid]]]}))
+    {:transact! (vec (map (fn [uid] [:db/retractEntity [:block/uid uid]]) (get-children-recursively uid)))}))
 
 
 (reg-event-fx


### PR DESCRIPTION
`:db/retractEntity` does not seem to recursively retract all child entities.

* Add `get-id` and `get-children-recursively` functions back to `db.cljs`
* Use `:db/retractEntity` instead of :db/retract in the `:page/delete` event handler since `:db/retractEntity` does retract the given entity and all it's attrs.